### PR TITLE
Gradle updates

### DIFF
--- a/android/mobile/build.gradle
+++ b/android/mobile/build.gradle
@@ -41,7 +41,7 @@ android {
 dependencies {
     compile project(":core")
 
-    def supportVersion = '25.1.0'
+    def supportVersion = '25.2.0'
     compile "com.android.support:appcompat-v7:${supportVersion}"
     compile "com.android.support:support-v13:${supportVersion}"
     compile "com.android.support:recyclerview-v7:${supportVersion}"

--- a/android/mobile/build.gradle
+++ b/android/mobile/build.gradle
@@ -9,21 +9,21 @@ buildProperties {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "23.0.3"
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
-        applicationId "com.novoda.peepz"
+        applicationId 'com.novoda.peepz'
         minSdkVersion 21
         targetSdkVersion 22
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
     signingConfigs {
         debug {
-            storeFile file("../debug.keystore")
+            storeFile file('../debug.keystore')
             storePassword buildProperties.debugSigning['storePassword'].string
             keyAlias buildProperties.debugSigning['keyAlias'].string
             keyPassword buildProperties.debugSigning['keyPassword'].string

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,3 @@
-rootProject.name = 'peepz-android'
+rootProject.name = 'peepz'
 include ':core'
 include ':mobile'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,3 @@
+rootProject.name = 'peepz-android'
 include ':core'
 include ':mobile'


### PR DESCRIPTION
**Problem:** Since the folder of the android project is just `android`, it is listed as just `android` in my Android Studio projects.

My main goal was just to change android project name. 

Project name is now `peepz-android`, can easily change to whatever you want.

Also did:
- Prefer single quotes over double quotes.
- buildTools version 25.0.2, (23 is really old)
- support lib version updated