### PR TITLE
Android: Update signing to just set the file

### DIFF
--- a/android/debugSigning.properties
+++ b/android/debugSigning.properties
@@ -1,3 +1,0 @@
-storePassword=android
-keyAlias=androiddebugkey
-keyPassword=android

--- a/android/mobile/build.gradle
+++ b/android/mobile/build.gradle
@@ -1,12 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.neenbedankt.android-apt'
 
-buildProperties {
-    debugSigning {
-        file rootProject.file('debugSigning.properties')
-    }
-}
-
 android {
     compileSdkVersion 25
     buildToolsVersion "23.0.3"
@@ -22,12 +16,7 @@ android {
     }
 
     signingConfigs {
-        debug {
-            storeFile file("../debug.keystore")
-            storePassword buildProperties.debugSigning['storePassword'].string
-            keyAlias buildProperties.debugSigning['keyAlias'].string
-            keyPassword buildProperties.debugSigning['keyPassword'].string
-        }
+        debug.storeFile rootProject.file('debug.keystore')
     }
 
     buildTypes {


### PR DESCRIPTION
Since the debug signing uses the default android passwords etc, it is not necessary to set them. 
So the signing config setup is actually just 1 line.

Manual testing done: 
- Installed first the APK shared by @ataulm 
- Run the app from Android Studio
- It was able to install on top of that